### PR TITLE
Fix the solution to Exercise 14.52

### DIFF
--- a/ch14/14.52.cpp
+++ b/ch14/14.52.cpp
@@ -47,7 +47,6 @@ int main() {
   ld = si + ld;  // Error
   // candidate functions
   //   all built-in operator+
-  //   LongDouble::operator+(const SmallInt&)
   //   operator+(LongDouble&, double)
   //   operator+(const SmallInt&, const SmallInt&)
   //


### PR DESCRIPTION
In the case of `ld = si + ld;` where the left operand is a `SmallInt`, I do not think that the member function of `LongDouble` is a candidate. Please let me know if I made a mistake.