### PR TITLE
Fix solution to 3.20

### DIFF
--- a/ch3/3.20.cpp
+++ b/ch3/3.20.cpp
@@ -4,7 +4,7 @@
 void sum_adjacent(const std::vector<int> &v) {
   if (v.size() < 2)
     return;
-  for (decltype(v.size()) i = 0; i < v.size() - 1; ++i)
+  for (decltype(v.size()) i = 0; i + 1 < v.size(); ++i)
     std::cout << v[i] + v[i + 1] << '\t';
   std::cout << std::endl;
 }


### PR DESCRIPTION
v.size()-1 will "wrap around" if the vector is empty, making the loop condition true. The program therefore tries to access invalid subsripts if the vector is empty.