### PR TITLE
Fix the solution to Exercise 15.14

### DIFF
--- a/ch15/15.14.cpp
+++ b/ch15/15.14.cpp
@@ -27,7 +27,7 @@ int main() {
   dobj.print(std::cout);
   // (c) base::name();
   bp1->name();
-  // (d) base::name();
+  // (d) derived::name();
   bp2->name();
   // (e) base::print();
   br1.print(std::cout);


### PR DESCRIPTION
Since `bp2` is a pointer that points to a `derived` object, I think it is the `derived::print(ostream&)` function that will be called at run time.