### PR TITLE
Fix solution in 1.23.cpp

### DIFF
--- a/ch1/1.23.cpp
+++ b/ch1/1.23.cpp
@@ -9,7 +9,6 @@ int main() {
       if (item.isbn() == curItem.isbn())
         ++cnt;
       else {
-        std::cout << curItem.isbn() << " " << cnt << std::endl;
         curItem = item;
         cnt = 1;
       }


### PR DESCRIPTION
Given that the `std::cout` at the end of the while loop will be executed with every iteration, I think that adding a second `cout` inside the `else` branch might be redundant, as I believe that the values involved don't get a chance to change inbetween the two.

Is there a case I'm missing where that statement is the only one able to catch the right values?