### PR TITLE
Update 6.22.cpp

### DIFF
--- a/ch6/6.22.cpp
+++ b/ch6/6.22.cpp
@@ -20,7 +20,9 @@ int main() {
   swapIntPtr(&pi, &pj);
   std::cout << "pi = " << pi << " *pi = " << *pi << std::endl;
   std::cout << "pj = " << pj << " *pj = " << *pj << std::endl;
-  swapIntPtr(pi, pj);
+  
+  int **ppi = &pi, **ppj = &pj; // pointer to pointer
+  swapIntPtr(ppi, ppj);
   std::cout << "pi = " << pi << " *pi = " << *pi << std::endl;
   std::cout << "pj = " << pj << " *pj = " << *pj << std::endl;
 


### PR DESCRIPTION
swapIntPtr requires arguments of pointer to pointer to int.