### PR TITLE
Update 11.29.md

### DIFF
--- a/ch11/11.29.md
+++ b/ch11/11.29.md
@@ -1,5 +1,4 @@
 When we pass a key that is not in container,
 
-- `upper_bound` will return `c.end()`,
-- `lower_bound` will return `c.end()`,
-- `equal_range` will return `make_pair(c.end(), c.end())`.
+- `upper_bound` and `lower_bound` will return equal iterators refer to the same position in which the key can be inserted without distupting the order. Specially, if the key has a value    that is larger than any that of other keys in the container, both of `upper_bound` and `lower_bound` will return `c.end()`.
+- `equal_range` will return `make_pair(iterator1, iterator2)`, in which `iterator1 == iterator2`. Both of them refer to the position in which the key can be inserted without distupting the order. Specially, if the key has a value that is larger than any that of other keys in the container, both of `iterator1` and `iterator2` will return `c.end()`.


### PR DESCRIPTION
the iterators returned are not always referred to c.end()