### PR TITLE
Update 13.5.cpp

### DIFF
--- a/ch13/13.5.cpp
+++ b/ch13/13.5.cpp
@@ -5,8 +5,11 @@ class HasPtr {
 public:
   HasPtr(const std::string &s = std::string())
       : ps(new std::string(s)), i(0) {}
-  HasPtr(const HasPtr &ori)
-      : ps(new std::string(*ori.ps)), i(ori.i) {}
+  HasPtr(const HasPtr &ori) {
+    auto nps = ori.ps;
+        delete ps;
+        ps = new string(*nps);
+  }
 
   const std::string &get() const { return *ps; }
   void set(const std::string &s) { *ps = s; }


### PR DESCRIPTION
1. ps is a plain pointer and may points to other objects, so we must delete it to prevent the memory leak;
2. add a variable nps so that it also works if a HasPtr is copying itself.